### PR TITLE
Add filter bits for trigger object matching for trigger scale factors

### DIFF
--- a/Run2017_CMSSW_10_6_28_UL/embedding_nanoaod.py
+++ b/Run2017_CMSSW_10_6_28_UL/embedding_nanoaod.py
@@ -103,6 +103,152 @@ process.pfMetPuppi.metSource = cms.InputTag("slimmedMETsPuppi", "", "RERUNPUPPI"
 
 # Customisation from command line
 
+# add additional filters to TrigObj_filterBits column in NANOAOD
+# these filters are needed in order to process the correct trigger object matching for applying
+# the trigger scale factors on embedding samples
+# See also https://twiki.cern.ch/twiki/bin/viewauth/CMS/TauTauEmbeddingSamples2017
+
+# modify the electron entry
+process.triggerObjectTable.selections[0].qualityBits = cms.string(
+    "filter('*CaloIdLTrackIdLIsoVL*TrackIso*Filter') + " \
+    "2*filter('hltEle*WPTight*TrackIsoFilter*') + " \
+    "4*filter('hltEle*WPLoose*TrackIsoFilter') + " \
+    "8*filter('*OverlapFilter*IsoEle*PFTau*') + " \
+    "16*filter('hltEle*Ele*CaloIdLTrackIdLIsoVL*Filter') + " \
+    "32*filter('hltMu*TrkIsoVVL*Ele*CaloIdLTrackIdLIsoVL*Filter*')  + " \
+    "64*filter('hltOverlapFilterIsoEle*PFTau*') + " \
+    "128*filter('hltEle*Ele*Ele*CaloIdLTrackIdLDphiLeg*Filter') + " \
+    "256*max(filter('hltL3fL1Mu*DoubleEG*Filtered*'),filter('hltMu*DiEle*CaloIdLTrackIdLElectronleg*Filter')) + " \
+    "512*max(filter('hltL3fL1DoubleMu*EG*Filter*'),filter('hltDiMu*Ele*CaloIdLTrackIdLElectronleg*Filter')) + " \
+    "1024*min(filter('hltEle32L1DoubleEGWPTightGsfTrackIsoFilter'),filter('hltEGL1SingleEGOrFilter')) + " \
+    "2048*filter('hltEle*CaloIdVTGsfTrkIdTGsfDphiFilter') + " \
+    "4096*path('HLT_Ele*PFJet*') + " \
+    "8192*max(filter('hltEG175HEFilter'),filter('hltEG200HEFilter')) + " \
+    "16384*filter('hltEle27WPTightGsfTrackIsoFilter') + " \
+    "32768*filter('hltEle32WPTightGsfTrackIsoFilter') + " \
+    "65536*filter('hltEle32L1DoubleEGWPTightGsfTrackIsoFilter') + " \
+    "131072*filter('hltEGL1SingleEGOrFilter') + " \
+    "262144*filter('hltEle35noerWPTightGsfTrackIsoFilter') + " \
+    "524288*filter('hltEle24erWPTightGsfTrackIsoFilterForTau')"
+)
+
+# add documentation for electron filter bits
+process.triggerObjectTable.selections[0].qualityBitsDoc = cms.string(
+    "1 = CaloIdL_TrackIdL_IsoVL, " \
+    "2 = 1e (WPTight), " \
+    "4 = 1e (WPLoose), " \
+    "8 = OverlapFilter PFTau, " \
+    "16 = 2e, " \
+    "32 = 1e-1mu, " \
+    "64 = 1e-1tau, " \
+    "128 = 3e, " \
+    "256 = 2e-1mu, " \
+    "512 = 1e-2mu, " \
+    "1024 = 1e (32_L1DoubleEG_AND_L1SingleEGOr), " \
+    "2048 = 1e (CaloIdVT_GsfTrkIdT), " \
+    "4096 = 1e (PFJet), " \
+    "8192 = 1e (Photon175_OR_Photon200), " \
+    "16384 = 1e (for e leg trigger object matching in embedding), " \
+    "32768 = 1e (for e leg trigger object matching in embedding), " \
+    "65536 = 1e (for e leg trigger object matching in embedding), " \
+    "131072 = 1e (for e leg trigger object matching in embedding), " \
+    "262144 = 1e (for e leg trigger object matching in embedding), " \
+    "524288 = 1e (for e leg trigger object matching in embedding)"
+)
+
+# modify the muon entry
+process.triggerObjectTable.selections[2].qualityBits = cms.string(
+    "filter('*RelTrkIsoVVLFiltered0p4') + " \
+    "2*filter('hltL3crIso*Filtered0p07') + " \
+    "4*filter('*OverlapFilterIsoMu*PFTau*') + " \
+    "8*max(filter('hltL3crIsoL1*SingleMu*Filtered0p07'),filter('hltL3crIsoL1sMu*Filtered0p07')) + " \
+    "16*filter('hltDiMuon*Filtered*') + " \
+    "32*filter('hltMu*TrkIsoVVL*Ele*CaloIdLTrackIdLIsoVL*Filter*') + " \
+    "64*filter('hltOverlapFilterIsoMu*PFTau*') + " \
+    "128*filter('hltL3fL1TripleMu*') + " \
+    "256*max(filter('hltL3fL1DoubleMu*EG*Filtered*'),filter('hltDiMu*Ele*CaloIdLTrackIdLElectronleg*Filter')) + " \
+    "512*max(filter('hltL3fL1Mu*DoubleEG*Filtered*'),filter('hltMu*DiEle*CaloIdLTrackIdLElectronleg*Filter')) + " \
+    "1024*max(filter('hltL3fL1sMu*L3Filtered50*'),filter('hltL3fL1sMu*TkFiltered50*')) + " \
+    "2048*max(filter('hltL3fL1sMu*L3Filtered100*'),filter('hltL3fL1sMu*TkFiltered100*')) + " \
+    "4096*filter('hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered0p07') + " \
+    "8192*filter('hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p07') + " \
+    "16384*filter('hltL3crIsoL1sMu18erTau24erIorMu20erTau24erL1f0L2f10QL3f20QL3trkIsoFiltered0p07')"
+)
+
+# add documentation for muon filter bits
+process.triggerObjectTable.selections[2].qualityBitsDoc = cms.string(
+    "1 = TrkIsoVVL, " \
+    "2 = Iso, " \
+    "4 = OverlapFilter PFTau, " \
+    "8 = 1mu, " \
+    "16 = 2mu, " \
+    "32 = 1mu-1e, " \
+    "64 = 1mu-1tau, " \
+    "128 = 3mu, " \
+    "256 = 2mu-1e, " \
+    "512 = 1mu-2e, " \
+    "1024 = 1mu (Mu50), " \
+    "2048 = 1mu (Mu100), " \
+    "4096 = 1mu (for mu leg trigger object matching in embedding), " \
+    "8192 = 1mu (for mu leg trigger object matching in embedding), " \
+    "16384 = 1mu (for mu leg trigger object matching in embedding)"
+)
+
+# modify the selection string in the tau entry
+process.triggerObjectTable.selections[3].sel = cms.string(
+    "( type(84) || type(-100) ) && " \
+    "(pt > 5) && " \
+    "coll('*Tau*') &&" \
+    "( filter('*LooseChargedIso*') || " \
+    "filter('*MediumChargedIso*') || " \
+    "filter('*TightChargedIso*') || " \
+    "filter('*TightOOSCPhotons*') || " \
+    "filter('hltL2TauIsoFilter') || " \
+    "filter('*OverlapFilterIsoMu*') || " \
+    "filter('*OverlapFilterIsoEle*') || " \
+    "filter('*L1HLTMatched*') || " \
+    "filter('*Dz02*') || " \
+    "filter('*DoublePFTau*') || " \
+    "filter('*SinglePFTau*') || " \
+    "filter('hlt*SelectedPFTau') || " \
+    "filter('*DisplPFTau*') || " \
+    "filter('*Tau*') )"
+)
+
+# modify the tau entry
+process.triggerObjectTable.selections[3].qualityBits = cms.string(
+    "filter('*LooseChargedIso*') + " \
+    "2*filter('*MediumChargedIso*') + " \
+    "4*filter('*TightChargedIso*') + " \
+    "8*filter('*TightOOSCPhotons*') + " \
+    "16*filter('*Hps*') + " \
+    "32*filter('hltSelectedPFTau*MediumChargedIsolationL1HLTMatched*') + " \
+    "64*filter('hltDoublePFTau*TrackPt1*ChargedIsolation*Dz02Reg') + " \
+    "128*filter('hltOverlapFilterIsoEle*PFTau*') + " \
+    "256*filter('hltOverlapFilterIsoMu*PFTau*') + " \
+    "512*filter('hltDoublePFTau*TrackPt1*ChargedIsolation*') + " \
+    "1024*filter('hltL1sBigORLooseIsoEGXXerIsoTauYYerdRMin0p3') + " \
+    "2048*filter('hltL1sMu18erTau24erIorMu20erTau24er') + " \
+    "4096*filter('hltDoubleL2IsoTau26eta2p2')"
+)
+
+# add documentation for tau filter bits
+process.triggerObjectTable.selections[3].qualityBitsDoc = cms.string(
+    "1 = LooseChargedIso, " \
+    "2 = MediumChargedIso, " \
+    "4 = TightChargedIso, " \
+    "8 = TightID OOSC photons, " \
+    "16 = HPS, " \
+    "32 = single-tau + tau+MET, " \
+    "64 = di-tau, " \
+    "128 = e-tau, " \
+    "256 = mu-tau, " \
+    "512 = VBF+di-tau, " \
+    "1024 = e-tau (for tau leg trigger object matching in embedding), " \
+    "2048 = mu-tau (for tau leg trigger object matching in embedding), " \
+    "4096 = di-tau (for tau leg trigger object matching in embedding)"
+)
+
 # Add early deletion of temporary data products to reduce peak memory need
 from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
 process = customiseEarlyDelete(process)


### PR DESCRIPTION
The trigger object matching on embedded events requires filters that are not written to ``nanoAOD`` files by default. These filters are added here to the config file for ``nanoAOD`` production for the 2017 data-taking era.

The required filter names are taken from the [TauTauEmbeddingSamples2017](https://twiki.cern.ch/twiki/bin/viewauth/CMS/TauTauEmbeddingSamples2017) TWiki page.